### PR TITLE
Falling back from subdomain if file not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ domain. This could be used to inject jquery (or any other js) into every site.
 If there is a `default.css` file in the `chromedotfiles` directory it will be injected into *every*
 domain.
 
+If there is no specific file for a site with a subdomain, *sub1.mydomain.com*, a file without the
+subdomain will be injected (e.g. `mydomain.com.js`).
 
 ### Differences from [dotjs](https://github.com/defunkt/dotjs)
 


### PR DESCRIPTION
If a site has multiple subdomains:

- sub1.mydomain.com
- sub2.mydomain.com
- sub3.mydomain.com

Currently you have to create/symlink three separate files to run the JS.

This change allows `mydomain.com.js` to also trigger when visiting _*.mydomain.com_

This change is useful when subdomains are created dynamically like [Heroku review apps](https://devcenter.heroku.com/articles/github-integration-review-apps)