### PR TITLE
Support manifest v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ console.log('hello from chrome dotfiles');
 
 `google.com.css`
 ```
-body.hp {
-  background: #F00;
+html body {
+  background-color: #F00;
 }
 ```
 

--- a/background.js
+++ b/background.js
@@ -23,11 +23,13 @@ function insertCSS(tabId, hostname) {
     return;
   }
 
-  chrome.tabs.insertCSS(tabId, {
-    file: 'chromedotfiles/' + hostname + '.css',
-    runAt: 'document_start',
-    allFrames: true
-  }, function (res) {
+  chrome.scripting.insertCSS({
+    target: {
+      tabId: tabId,
+      allFrames: true
+    },
+    files: ['chromedotfiles/' + hostname + '.css']
+  }, function (_) {
     if (chrome.runtime.lastError) {
       // fail silently
       return;
@@ -41,9 +43,13 @@ function executeScript(tabId, hostname) {
   if (!hostname) {
     return;
   }
-  chrome.tabs.executeScript(tabId, {
-    file: 'chromedotfiles/' + hostname + '.js'
-  }, function(res) {
+  chrome.scripting.executeScript({
+    target: {
+      tabId: tabId,
+      allFrames: true,
+    },
+    files: ['chromedotfiles/' + hostname + '.js']
+  }, (_) => {
     if (chrome.runtime.lastError) {
       // fail silently
       return;

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "Chrome dotfiles",
   "version": "2.0.0",
   "description": "inject js and css into chrome tabs",
@@ -8,13 +8,14 @@
      "48": "icon-48.png"
   },
   "permissions": [
-    "http://*/",
-    "https://*/",
     "webNavigation",
-    "tabs"
+    "tabs",
+    "scripting"
+  ],
+  "host_permissions": [
+    "<all_urls>"
   ],
   "background": {
-    "persistent": false,
-    "scripts": ["background.js"]
+    "service_worker": "background.js"
   }
 }


### PR DESCRIPTION
# What will be change in this PR

- Update manifest file
  - Change manifest version from v2 to v3
  - Remove the url pattern permissions from the permission attribute and add `<all_urls>` permission to access any urls
  - Add `scripting` permission to call `chrome.scripting` API
  - Register the background script as service worker
- Update background script
  - Use `chrome.scripting` API due to deprecation of previous API
- Update example css selector to works fine

# What does not changed by this PR

- Chrome extension version
  - Please change the version if you want

## Referenced documents

- [Manifest V3 migration checklist - Chrome Developers](https://developer.chrome.com/docs/extensions/mv3/mv3-migration-checklist/)
- [chrome.scripting - Chrome Developers](https://developer.chrome.com/docs/extensions/reference/scripting/)